### PR TITLE
feat: accept arguments

### DIFF
--- a/src/backup_script.bash
+++ b/src/backup_script.bash
@@ -14,7 +14,7 @@
 # Finaliza a aplicação da formatação de cor.
 RESET='\e[0m'
 # Inicia a formatação de cor no texto.
-BLACK='\e[1;30m' 
+BLACK='\e[1;30m'
 RED='\e[1;31m'
 GREEN='\e[1;32m'
 YELLOW='\e[1;33m'
@@ -29,14 +29,8 @@ set -o errexit
 # Faz o script sair se tentar usar variável não definida.
 set -o nounset
 # Faz o script considerar erro em pipelines quando qualquer parte falhar.
-set -o pipefail
-
-# Ponto de inicialização do script.
-main() {
-    printf "${BLUE}Autores: L. Garzuze e T. Magalhães e Yohan Cys.${RESET}\n"
-    printf "${BLUE}=== Script de Backup com Rsync ===${RESET}\n\n"
-    menu
-}
+# set -o pipefail
+set -euo pipefail
 
 menu() {
     option=""
@@ -46,14 +40,14 @@ menu() {
     printf "Digite uma opção: "
     read -r option
 
-    # O return encerra a execução da função atual para evitar empilhamento de funções. 
+    # O return encerra a execução da função atual para evitar empilhamento de funções.
     # Desse modo, a pausa de execução em segundo plano não ocorre.
     case "$option" in
-        "1") 
+        "1")
             clear; runBackup; return;;
-        "2") 
+        "2")
             clear; printf "Script encerrado. Saindo...\n\n"; exit;;
-        "") 
+        "")
             clear;
             # Verifica se a entrada está vazia.
             printf "${YELLOW}*${RESET} Nenhuma opção foi digitada. Tente novamente.\n\n";
@@ -70,85 +64,82 @@ menu() {
 }
 
 runBackup() {
-    # Define o diretório de origem dos arquivos a serem salvos.
-    SOURCE_DIR=""
-    # Define onde os backups serão armazenados.
-    DEST_DIR=""
-    # Subdiretório criado automaticamente no diretório de destino.
-    BACKUP_DIR=""
-    # Nome do subdiretório de backup.
     BACKUP_SUBDIR_NAME="backups"
+    # Se SOURCE_DIR já estiver definido (via args), pula leitura interativa:
+    if [[ -z "${SOURCE_DIR:-}" ]]; then
+        # Seleção do diretório de origem.
+        while true; do
+            printf "[${CYAN}ORIGEM${RESET}] Informe o caminho completo (desde a raiz) do diretório desejado para backup.\n"
+            printf "Ex.: ${CYAN}/home/usuario/Documentos/${RESET}.\n\n"
+            printf "Digite o caminho de origem ou [${CYAN}2${RESET}] para voltar ao menu: "
+            read -r SOURCE_DIR
+            clear
 
-    # Seleção do diretório de origem.
-    while true; do
-        printf "[${CYAN}ORIGEM${RESET}] Informe o caminho completo (desde a raiz) do diretório desejado para backup.\n"
-        printf "Ex.: ${CYAN}/home/usuario/Documentos/${RESET}.\n\n"
-        printf "Digite o caminho de origem ou [${CYAN}2${RESET}] para voltar ao menu: "
-        read -r SOURCE_DIR
-        clear
+            # Verifica se a entrada está vazia (usuário não digitou nada).
+            if [[ -z "${SOURCE_DIR}" ]]; then
+                printf "${YELLOW}*${RESET} Nenhum caminho de origem foi digitado. Tente novamente.\n\n"
+                # Pula para a próxima iteração do laço.
+                continue
+            fi
 
-        # Verifica se a entrada está vazia (usuário não digitou nada).
-        if [[ -z "${SOURCE_DIR}" ]]; then
-            printf "${YELLOW}*${RESET} Nenhum caminho de origem foi digitado. Tente novamente.\n\n"
-            # Pula para a próxima iteração do laço.
-            continue
-        fi
+            # Verifica se foi digitado `2` para retornar ao main.
+            if [[ "${SOURCE_DIR}" == "2" ]]; then
+                main
+                return
+            fi
 
-        # Verifica se foi digitado `2` para retornar ao main.
-        if [[ "${SOURCE_DIR}" == "2" ]]; then
-            main
-            return
-        fi
+            if [[ -d "$SOURCE_DIR" ]]; then
+                # Se for um diretório válido, exibe o caminho completo desde a raiz.
+                printf "${GREEN}*${RESET} Diretório de origem localizado em: ${GREEN}%s${RESET}.\n\n" "$SOURCE_DIR"
+                # Encerra o laço atual (diretório de origem).
+                break
+            else
+                printf "${YELLOW}*${RESET} O caminho de origem informado não existe ou não é um diretório.\n"
+                printf "${YELLOW}*${RESET} Foi digitado: ${YELLOW}%s${RESET}.\n\n" "$SOURCE_DIR"
+            fi
+        done
 
-        if [[ -d "$SOURCE_DIR" ]]; then
-            # Se for um diretório válido, exibe o caminho completo desde a raiz. 
-            printf "${GREEN}*${RESET} Diretório de origem localizado em: ${GREEN}%s${RESET}.\n\n" "$SOURCE_DIR"
-            # Encerra o laço atual (diretório de origem). 
-            break
-        else
-            printf "${YELLOW}*${RESET} O caminho de origem informado não existe ou não é um diretório.\n"
-            printf "${YELLOW}*${RESET} Foi digitado: ${YELLOW}%s${RESET}.\n\n" "$SOURCE_DIR"
-        fi
-    done
+        # Seleção do diretório de destino.
+        while true; do
+            printf "[${CYAN}DESTINO${RESET}] Informe o caminho completo (desde a raiz) do diretório de armazenamento do backup.\n"
+            printf "Ex.: ${CYAN}/media/hd_externo/backups${RESET}.\n\n"
+            printf "Digite o caminho de destino ou [${CYAN}2${RESET}] para alterar o diretório de ORIGEM: "
+            read -r DEST_DIR
+            clear
 
-    # Seleção do diretório de destino.
-    while true; do
-        printf "[${CYAN}DESTINO${RESET}] Informe o caminho completo (desde a raiz) do diretório de armazenamento do backup.\n"
-        printf "Ex.: ${CYAN}/media/hd_externo/backups${RESET}.\n\n"
-        printf "Digite o caminho de destino ou [${CYAN}2${RESET}] para alterar o diretório de ORIGEM: "
-        read -r DEST_DIR
-        clear
+            # Verifica se a entrada está vazia (usuário não digitou nada).
+            if [[ -z "${DEST_DIR}" ]]; then
+                printf "${YELLOW}*${RESET} Nenhum caminho de destino foi digitado. Tente novamente.\n\n"
+                continue
+            fi
 
-        # Verifica se a entrada está vazia (usuário não digitou nada).
-        if [[ -z "${DEST_DIR}" ]]; then
-            printf "${YELLOW}*${RESET} Nenhum caminho de destino foi digitado. Tente novamente.\n\n"
-            continue
-        fi
+            # Verifica se foi digitado `2` para alterar diretório de origem.
+            if [[ "${DEST_DIR}" == "2" ]]; then
+                runBackup
+                return
+            fi
 
-        # Verifica se foi digitado `2` para alterar diretório de origem.
-        if [[ "${DEST_DIR}" == "2" ]]; then
-            runBackup
-            return
-        fi
+            # Combina o caminho do usuário com o nome da subpasta automática.
+            # O '%/' remove a barra final, se houver, para evitar '//'
+            BACKUP_DIR="${DEST_DIR%/}/${BACKUP_SUBDIR_NAME}"
 
-        # Combina o caminho do usuário com o nome da subpasta automática.
-        # O '%/' remove a barra final, se houver, para evitar '//'
-        BACKUP_DIR="${DEST_DIR%/}/${BACKUP_SUBDIR_NAME}"
+            # Tenta criar o diretório de destino, incluindo seu subdiretório. O '-p' evita erros se já existir.
+            mkdir -p "${BACKUP_DIR}"
 
-        # Tenta criar o diretório de destino, incluindo seu subdiretório. O '-p' evita erros se já existir.
-        mkdir -p "${BACKUP_DIR}"
+            # Verifica se o diretório existe e se é possível escrever nele.
+            if [[ -d "${BACKUP_DIR}" && -w "${BACKUP_DIR}" ]]; then
+                printf "${GREEN}*${RESET} O backup será salvo em: ${GREEN}%s${RESET}.\n\n" "$BACKUP_DIR"
 
-        # Verifica se o diretório existe e se é possível escrever nele.
-        if [[ -d "${BACKUP_DIR}" && -w "${BACKUP_DIR}" ]]; then
-            printf "${GREEN}*${RESET} O backup será salvo em: ${GREEN}%s${RESET}.\n\n" "$BACKUP_DIR"
-
-            # Encerra o laço atual (diretório de destino). 
-            break
-        else
-            printf "${YELLOW}*${RESET} O caminho de destino é inválido ou não há permissão de escrita.\n"
-            printf "${YELLOW}*${RESET} Foi digitado: ${YELLOW}%s${RESET}.\n\n" "$DEST_DIR"
-        fi 
-    done
+                # Encerra o laço atual (diretório de destino).
+                break
+            else
+                printf "${YELLOW}*${RESET} O caminho de destino é inválido ou não há permissão de escrita.\n"
+                printf "${YELLOW}*${RESET} Foi digitado: ${YELLOW}%s${RESET}.\n\n" "$DEST_DIR"
+            fi
+        done
+    fi
+    BACKUP_DIR="${DEST_DIR%/}/${BACKUP_SUBDIR_NAME}"
+    mkdir -p "${BACKUP_DIR}"
 
     # --- Definições dinâmica dos caminhos ---
     # As variáveis de backup agora são definidas com base na entrada do usuário.
@@ -161,7 +152,7 @@ runBackup() {
 
     # Confirmação final antes de executar o Rsync.
     printf "Deseja iniciar o backup de '${CYAN}%s${RESET}' para '${CYAN}%s${RESET}'?\n" "$SOURCE_DIR" "$BACKUP_DIR"
-    
+
     printf "Digite [${CYAN}1${RESET}] para confirmar ou qualquer outra tecla para cancelar: "
     read -r option
     clear
@@ -205,5 +196,20 @@ runBackup() {
     main
     return
 }
+# Ponto de inicialização do script.
+main() {
+    printf "${BLUE}Autores: L. Garzuze e T. Magalhães e Yohan Cys.${RESET}\n"
+    printf "${BLUE}=== Script de Backup com Rsync ===${RESET}\n\n"
+    menu
+}
 
+# Se vierem exatamente 2 parâmetros, usá‑los e pular menu:
+if [[ $# -eq 2 ]]; then
+    SOURCE_DIR="$1"
+    DEST_DIR="$2"
+    runBackup
+    exit 0
+fi
+
+# Senão, continuar em modo interativo:
 main


### PR DESCRIPTION
Tornar possível utilizar argumentos no script, sem precisar digitar origem e destino após o menu. Quero tornar possível utilizar o script com o cronjobs. Ainda não é possível dessa forma, pois, mesmo usando argumentos, ainda é necessário confirmar o backup digitando 1. Em breve vou criar uma versão que não exiga essa confirmação, caso o script tenha sido rodado com args.